### PR TITLE
temporarily disable auto-opening for `aframe {serve,deploy,submit}` commands (for issue #55)

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -158,7 +158,7 @@ const deployToIPFS = (options, deployPath, rootDir, pkgObj) => {
         clipboardy.writeSync(deployedUrl);
       }
       if (!options.noOpen) {
-        opn(deployedUrl, {wait: false});
+        // opn(deployedUrl, {wait: false});
       }
       if (!options.noSubmit) {
         submitToIndex(deployedUrl);

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -80,7 +80,7 @@ const serve = (watchPath, options) => new Promise((resolve, reject) => {
         clipboardy.writeSync(serverUrl);
       }
       if (!options.noOpen) {
-        opn(serverUrl, {wait: false});
+        // opn(serverUrl, {wait: false});
       }
       resolve(serverUrl);
     });

--- a/lib/submit.js
+++ b/lib/submit.js
@@ -32,7 +32,7 @@ const submit = (siteUrl, options) => new Promise((resolve, reject) => {
       clipboardy.writeSync(worksUrl);
     }
     if (!options.noOpen) {
-      opn(worksUrl, {wait: false});
+      // opn(worksUrl, {wait: false});
     }
     return worksUrl;
   }).then(() => {


### PR DESCRIPTION
disabling auto-opening (for issue #55). there's a bug with the options with using `commander`, which I'm resolving in a local branch by replacing it with something less auto-magical.